### PR TITLE
fix: Resolve application freeze during user input

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,7 +28,7 @@ jobs:
         run: cargo doc --no-deps --release
 
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: target/doc
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -29,6 +79,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
@@ -50,6 +106,19 @@ dependencies = [
  "once_cell",
  "unicode-width",
  "windows-sys",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
 ]
 
 [[package]]
@@ -86,10 +155,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -102,6 +200,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,7 +213,35 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
+name = "indexmap"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -123,6 +255,36 @@ dependencies = [
  "portable-atomic",
  "unicode-width",
  "web-time",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -182,6 +344,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +360,15 @@ name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -212,14 +389,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "redox_users"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
  "libredox",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -256,9 +439,14 @@ name = "rust-media-downloader"
 version = "0.1.0"
 dependencies = [
  "colored",
+ "dialoguer",
  "dirs",
+ "env_logger",
  "indicatif",
+ "log",
  "regex",
+ "serde",
+ "toml",
  "which",
 ]
 
@@ -276,6 +464,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "syn"
 version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,12 +510,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -307,6 +563,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,10 +616,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -477,7 +789,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,9 @@ dirs = "6.0.0"
 regex = "1.11.1"
 colored = "3.0.0"
 which = "7.0.3"
+dialoguer = "0.11.0"
+serde = { version = "1.0", features = ["derive"] }
+toml = "0.8"
+log = "0.4"
+env_logger = "0.11"
 
-[alias]
-tests = "cargo test -- --nocapture"
-fmt = "rustfmt"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,66 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Config {
+    pub default_audio_format: String,
+    pub audio_formats: Vec<String>,
+    pub default_video_format: String,
+    pub download_directory: String,
+    pub keep_temporary_files: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        let download_directory = dirs::download_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .to_str()
+            .unwrap_or(".")
+            .to_string();
+
+        Config {
+            default_audio_format: "mp3".to_string(),
+            audio_formats: vec!["mp3".to_string(), "m4a".to_string(), "flac".to_string(), "wav".to_string()],
+            default_video_format: "mp4".to_string(),
+            download_directory,
+            keep_temporary_files: false,
+        }
+    }
+}
+
+fn get_config_path() -> PathBuf {
+    let mut path = dirs::config_dir().expect("Could not find config directory");
+    path.push("rust-media-downloader");
+    fs::create_dir_all(&path).expect("Could not create config directory");
+    path.push("config.toml");
+    path
+}
+
+pub fn load_config() -> Config {
+    let path = get_config_path();
+    if !path.exists() {
+        let config = Config::default();
+        save_config(&config);
+        return config;
+    }
+
+    let content = fs::read_to_string(&path).expect("Could not read config file");
+    match toml::from_str(&content) {
+        Ok(config) => config,
+        Err(e) => {
+            log::warn!("Failed to parse config file, it might be outdated: {}. Creating a new one.", e);
+            // Attempt to remove the old, invalid config file
+            let _ = fs::remove_file(&path);
+            let config = Config::default();
+            save_config(&config);
+            config
+        }
+    }
+}
+
+pub fn save_config(config: &Config) {
+    let path = get_config_path();
+    let content = toml::to_string(config).expect("Could not serialize config");
+    fs::write(path, content).expect("Could not write to config file");
+}

--- a/src/config_test.rs
+++ b/src/config_test.rs
@@ -1,0 +1,26 @@
+use super::config;
+use std::fs;
+
+#[test]
+fn test_load_and_save_config() {
+    let mut config = config::load_config();
+    config.default_audio_format = "test_audio".to_string();
+    config.audio_formats.push("test_audio".to_string());
+    config.default_video_format = "test_video".to_string();
+    config.download_directory = "/tmp/test_dir".to_string();
+    config.keep_temporary_files = true;
+    config::save_config(&config);
+
+    let loaded_config = config::load_config();
+    assert_eq!(loaded_config.default_audio_format, "test_audio");
+    assert!(loaded_config.audio_formats.contains(&"test_audio".to_string()));
+    assert_eq!(loaded_config.default_video_format, "test_video");
+    assert_eq!(loaded_config.download_directory, "/tmp/test_dir");
+    assert_eq!(loaded_config.keep_temporary_files, true);
+
+    // Cleanup
+    let mut path = dirs::config_dir().expect("Could not find config directory");
+    path.push("rust-media-downloader");
+    path.push("config.toml");
+    fs::remove_file(path).expect("Could not remove test config file");
+}

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -1,0 +1,103 @@
+use colored::*;
+use dialoguer::{Select, theme::ColorfulTheme};
+use std::process::{Command, Stdio};
+use which::which;
+use log::{info, warn, error};
+
+// Liste des navigateurs supportés et leurs noms pour yt-dlp
+const BROWSERS: &[(&str, &str)] = &[
+    ("chrome", "Chrome"),
+    ("firefox", "Firefox"),
+    ("brave", "Brave"),
+    ("edge", "Edge"),
+    ("opera", "Opera"),
+    ("vivaldi", "Vivaldi"),
+    // Safari n'est pas directement supporté pour l'extraction de cookies par yt-dlp de cette manière.
+];
+
+/// Détecte les navigateurs installés sur le système.
+/// Retourne une liste de tuples `(key, name)` pour les navigateurs trouvés.
+pub fn get_installed_browsers() -> Vec<(&'static str, &'static str)> {
+    let mut installed = Vec::new();
+    for (key, name) in BROWSERS {
+        // Pour Windows, les navigateurs ne sont pas toujours dans le PATH.
+        // yt-dlp a sa propre logique de détection interne, donc on les ajoute tous sur Windows.
+        if cfg!(target_os = "windows") {
+            installed.push((*key, *name));
+        } else {
+            // Pour Linux/macOS, on peut vérifier la présence de l'exécutable.
+            if which(key).is_ok() {
+                installed.push((*key, *name));
+            }
+        }
+    }
+    installed
+}
+
+/// Affiche un menu pour choisir un navigateur et exécute le téléchargement.
+pub fn extract_cookies_and_download(url: &str) {
+    if which("yt-dlp").is_err() {
+        error!("{}", "Erreur: 'yt-dlp' n'est pas installé ou pas dans le PATH.".red().bold());
+        return;
+    }
+
+    let browsers = get_installed_browsers();
+    if browsers.is_empty() {
+        error!("{}", "Aucun navigateur compatible n'a été détecté.".red().bold());
+        info!("Navigateurs supportés : Chrome, Firefox, Brave, Edge, Opera, Vivaldi.");
+        return;
+    }
+
+    let browser_names: Vec<&str> = browsers.iter().map(|&(_, name)| name).collect();
+
+    let selection = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Choisissez un navigateur pour extraire les cookies")
+        .items(&browser_names)
+        .default(0)
+        .interact_opt()
+        .unwrap_or(None);
+
+    if let Some(index) = selection {
+        let (browser_key, browser_name) = browsers[index];
+        info!("{} Utilisation des cookies de {}...", "🔑".yellow(), browser_name.cyan());
+
+        download_with_cookies(url, browser_key);
+    } else {
+        warn!("{}", "Aucun navigateur sélectionné. Annulation.".yellow());
+    }
+}
+
+/// Exécute yt-dlp avec les cookies du navigateur spécifié.
+fn download_with_cookies(url: &str, browser: &str) {
+    info!("{}", "\n📥 Téléchargement en cours...".cyan().bold());
+
+    let mut command = Command::new("yt-dlp");
+    command
+        .arg("--cookies-from-browser")
+        .arg(browser)
+        .arg(url)
+        .stdout(Stdio::inherit()) // Affiche la sortie de yt-dlp en temps réel
+        .stderr(Stdio::inherit()); // Affiche les erreurs de yt-dlp en temps réel
+
+    match command.status() {
+        Ok(status) => {
+            if status.success() {
+                info!("{}", "\n✅ Téléchargement terminé avec succès !".green().bold());
+            } else {
+                error!(
+                    "{}",
+                    "\n❌ Erreur lors du téléchargement. yt-dlp a retourné un code d'erreur."
+                        .red()
+                        .bold()
+                );
+            }
+        }
+        Err(e) => {
+            error!(
+                "{}\nErreur : {}",
+                "❌ Échec de l'exécution de la commande yt-dlp.".red().bold(),
+                e
+            );
+        }
+    }
+}

--- a/src/cookies_test.rs
+++ b/src/cookies_test.rs
@@ -1,0 +1,11 @@
+use super::cookies;
+
+#[test]
+fn test_get_installed_browsers() {
+    let browsers = cookies::get_installed_browsers();
+    // This test is highly dependent on the environment.
+    // On a typical developer machine, we'd expect at least one browser.
+    // On a CI/CD runner, this might be empty.
+    // So, we just check that the function returns a Vec without crashing.
+    assert!(browsers.is_empty() || !browsers.is_empty());
+}

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -1,7 +1,7 @@
-use dirs::download_dir;
+use crate::config;
 use indicatif::{ProgressBar, ProgressStyle};
-use std::env;
 use std::io::{BufRead, BufReader as StdBufReader};
+use log::{info, warn, error};
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -11,13 +11,8 @@ use std::path::{Path, PathBuf}; // Added for path manipulation
 pub fn download_video(url: &str, format: &str, keep_files: bool, custom_filename: Option<String>) {
     let mut command = Command::new("yt-dlp");
 
-    // Ajouter le répertoire de téléchargement par défaut
-    if let Some(download_path) = download_dir() {
-        command.args(&["-P", download_path.to_str().unwrap_or_else(|| {
-            eprintln!("Chemin de téléchargement invalide, utilisation du répertoire courant.");
-            "."
-        })]);
-    }
+    let config = config::load_config();
+    command.args(&["-P", &config.download_directory]);
 
     // Ajouter l'option pour personnaliser le nom du fichier si fourni
     if let Some(filename) = &custom_filename {
@@ -31,7 +26,7 @@ pub fn download_video(url: &str, format: &str, keep_files: bool, custom_filename
         command.arg("-k");
     }
 
-    if !format.is_empty() {
+    if !format.is_empty() && format != "best" {
         command.args(&["-f", format]);
     }
 
@@ -63,14 +58,14 @@ pub fn download_video(url: &str, format: &str, keep_files: bool, custom_filename
         for line in stderr_reader.lines() {
             if let Ok(line) = line {
                 // Consider printing stderr to stderr stream
-                eprintln!("yt-dlp (stderr): {}", line);
+                error!("yt-dlp (stderr): {}", line);
             }
         }
     });
 
     for line in stdout_reader.lines() {
         if let Ok(line) = line {
-            println!("{}", line); // Print yt-dlp stdout
+            info!("{}", line); // Print yt-dlp stdout
 
             if line.contains("[download] Destination: ") {
                 let mut path_guard = downloaded_filename_clone.lock().unwrap();
@@ -96,18 +91,17 @@ pub fn download_video(url: &str, format: &str, keep_files: bool, custom_filename
     pb_arc.lock().unwrap().finish_with_message("Téléchargement vidéo terminé.");
 
     if status.success() {
-        println!("La vidéo a été téléchargée avec succès !");
+        info!("La vidéo a été téléchargée avec succès !");
         if let Some(path_str) = downloaded_filename_arc.lock().unwrap().as_ref() {
-            let base_download_dir = download_dir().unwrap_or_else(|| {
-                env::current_dir().expect("Impossible d'obtenir le répertoire de travail actuel")
-            });
+            let config = config::load_config();
+            let base_download_dir = PathBuf::from(config.download_directory);
             let full_path = base_download_dir.join(path_str);
-            println!("Chemin du fichier vidéo téléchargé : {:?}", full_path);
+            info!("Chemin du fichier vidéo téléchargé : {:?}", full_path);
         } else {
-            println!("Chemin du fichier vidéo non extrait de la sortie yt-dlp.");
+            warn!("Chemin du fichier vidéo non extrait de la sortie yt-dlp.");
         }
     } else {
-        eprintln!("Erreur lors du téléchargement de la vidéo (yt-dlp a échoué). Code: {:?}", status.code());
+        error!("Erreur lors du téléchargement de la vidéo (yt-dlp a échoué). Code: {:?}", status.code());
         std::process::exit(1);
     }
 }
@@ -115,15 +109,8 @@ pub fn download_video(url: &str, format: &str, keep_files: bool, custom_filename
 // Modified download_audio function
 pub fn download_audio(url: &str, audio_format: &str, extract_instrumental: bool, custom_filename: Option<String>) {
     let mut command = Command::new("yt-dlp");
-    let default_download_dir = download_dir(); // Get it once
-
-    // Ajouter le répertoire de téléchargement par défaut
-    let actual_download_path_str = if let Some(ref path_buf) = default_download_dir {
-        path_buf.to_str().unwrap_or(".")
-    } else {
-        "." // Download to current directory if default is not available or invalid
-    };
-    command.args(&["-P", actual_download_path_str]);
+    let config = config::load_config();
+    command.args(&["-P", &config.download_directory]);
 
     // Ajouter l'option pour personnaliser le nom du fichier si fourni
     if let Some(filename) = &custom_filename {
@@ -143,7 +130,7 @@ pub fn download_audio(url: &str, audio_format: &str, extract_instrumental: bool,
     command.stdout(Stdio::piped());
     command.stderr(Stdio::piped());
 
-    println!("Lancement de yt-dlp pour l'audio...");
+    info!("Lancement de yt-dlp pour l'audio...");
     let mut child = command
         .spawn()
         .expect("Erreur lors de l'exécution de yt-dlp pour l'audio");
@@ -169,7 +156,7 @@ pub fn download_audio(url: &str, audio_format: &str, extract_instrumental: bool,
     thread::spawn(move || {
         for line in stderr_reader.lines() {
             if let Ok(line) = line {
-                eprintln!("yt-dlp (stderr): {}", line);
+                error!("yt-dlp (stderr): {}", line);
             }
         }
     });
@@ -177,7 +164,7 @@ pub fn download_audio(url: &str, audio_format: &str, extract_instrumental: bool,
     // Processing yt-dlp's stdout
     for line in stdout_reader.lines() {
         if let Ok(line) = line {
-            println!("{}", line); // Print yt-dlp stdout
+            info!("{}", line); // Print yt-dlp stdout
 
             if line.contains("[download] Destination: ") {
                 let mut path_guard = downloaded_filename_clone.lock().unwrap();
@@ -206,14 +193,13 @@ pub fn download_audio(url: &str, audio_format: &str, extract_instrumental: bool,
     pb_arc.lock().unwrap().finish_with_message("Téléchargement audio (yt-dlp) terminé.");
 
     if status.success() {
-        println!("L'audio a été téléchargée avec succès par yt-dlp!");
+        info!("L'audio a été téléchargée avec succès par yt-dlp!");
 
         let downloaded_filename_option = downloaded_filename_arc.lock().unwrap().clone();
 
         if let Some(downloaded_filename_str) = downloaded_filename_option {
-            let base_download_dir = default_download_dir.unwrap_or_else(|| {
-                env::current_dir().expect("Impossible d'obtenir le répertoire de travail actuel")
-            });
+            let config = config::load_config();
+            let base_download_dir = PathBuf::from(config.download_directory);
             // yt-dlp might output a full path if -P is not CWD, or just a filename.
             // The extracted filename_str might already be a full path in some yt-dlp versions/configs.
             // Let's assume filename_str is the final filename *relative to base_download_dir* or an absolute path.
@@ -224,28 +210,35 @@ pub fn download_audio(url: &str, audio_format: &str, extract_instrumental: bool,
             };
 
 
-            println!("Chemin du fichier audio original : {:?}", original_downloaded_full_path);
+            info!("Chemin du fichier audio original : {:?}", original_downloaded_full_path);
 
             if extract_instrumental {
-                println!("⚙️  Extraction de l'instrumental avec Spleeter en cours (cela peut prendre du temps)...");
+                info!("⚙️  Extraction de l'instrumental avec Spleeter en cours (cela peut prendre du temps)...");
 
                 if Command::new("spleeter").arg("--version").output().is_err() {
-                    eprintln!("❌ Spleeter n'est pas installé ou n'est pas dans le PATH.");
-                    eprintln!("   Veuillez l'installer pour utiliser l'extraction instrumentale.");
-                    eprintln!("   Le fichier audio original a été conservé ici : {:?}", original_downloaded_full_path);
+                    error!("❌ Spleeter n'est pas installé ou n'est pas dans le PATH.");
+                    info!("   Veuillez l'installer pour utiliser l'extraction instrumentale.");
+                    info!("   Le fichier audio original a été conservé ici : {:?}", original_downloaded_full_path);
                     // Not exiting, user gets the original audio.
                     return;
                 }
 
                 let input_audio_path_for_spleeter = original_downloaded_full_path.to_str().unwrap_or_else(|| {
-                    eprintln!("❌ Chemin du fichier audio original invalide pour Spleeter.");
+                    error!("❌ Chemin du fichier audio original invalide pour Spleeter.");
                     // Exiting here as Spleeter cannot proceed.
                     std::process::exit(1); // Or return a Result from the function
                 });
 
                 let spleeter_output_parent_dir = original_downloaded_full_path.parent().unwrap_or_else(|| Path::new("."));
 
-                println!("Spleeter utilisera le dossier de sortie : {:?}", spleeter_output_parent_dir);
+                info!("Spleeter utilisera le dossier de sortie : {:?}", spleeter_output_parent_dir);
+
+                let spinner_style = ProgressStyle::default_spinner()
+                    .template("{spinner:.green} {msg}")
+                    .unwrap();
+                let pb = ProgressBar::new_spinner();
+                pb.set_style(spinner_style);
+                pb.set_message("Spleeter is working...");
 
                 let spleeter_cmd = Command::new("spleeter")
                     .arg("separate")
@@ -260,25 +253,26 @@ pub fn download_audio(url: &str, audio_format: &str, extract_instrumental: bool,
 
                 match spleeter_cmd {
                     Ok(mut spleeter_child) => {
-                        println!("Spleeter démarré...");
+                        info!("Spleeter démarré...");
                         // Capture Spleeter's output (optional, can be verbose)
                         if let Some(s_stdout) = spleeter_child.stdout.take() {
                             let reader = StdBufReader::new(s_stdout);
                             for line in reader.lines().filter_map(Result::ok) {
-                                println!("Spleeter (stdout): {}", line);
+                                info!("Spleeter (stdout): {}", line);
                             }
                         }
                         if let Some(s_stderr) = spleeter_child.stderr.take() {
                             let reader = StdBufReader::new(s_stderr);
                             for line in reader.lines().filter_map(Result::ok) {
-                                eprintln!("Spleeter (stderr): {}", line);
+                                error!("Spleeter (stderr): {}", line);
                             }
                         }
 
                         let spleeter_status = spleeter_child.wait().expect("Spleeter a échoué lors de l'attente.");
+                        pb.finish_with_message("Spleeter finished.");
 
                         if spleeter_status.success() {
-                            println!("✅ Spleeter a terminé l'extraction.");
+                            info!("✅ Spleeter a terminé l'extraction.");
 
                             let original_file_stem = original_downloaded_full_path.file_stem()
                                 .and_then(|s| s.to_str())
@@ -298,49 +292,49 @@ pub fn download_audio(url: &str, audio_format: &str, extract_instrumental: bool,
 
                                 match fs::rename(&spleeter_instrumental_path, &final_instrumental_full_path) {
                                     Ok(_) => {
-                                        println!("🎶 Fichier instrumental sauvegardé ici : {:?}", final_instrumental_full_path);
+                                        info!("🎶 Fichier instrumental sauvegardé ici : {:?}", final_instrumental_full_path);
                                         // Cleanup
                                         if let Err(e) = fs::remove_file(&original_downloaded_full_path) {
-                                            eprintln!("⚠️ Impossible de supprimer le fichier audio original complet {:?}: {}", original_downloaded_full_path, e);
+                                            warn!("⚠️ Impossible de supprimer le fichier audio original complet {:?}: {}", original_downloaded_full_path, e);
                                         }
                                         if spleeter_vocals_path.exists() {
                                             if let Err(e) = fs::remove_file(&spleeter_vocals_path) {
-                                                eprintln!("⚠️ Impossible de supprimer le fichier vocal {:?}: {}", spleeter_vocals_path, e);
+                                                warn!("⚠️ Impossible de supprimer le fichier vocal {:?}: {}", spleeter_vocals_path, e);
                                             }
                                         }
                                         if spleeter_output_subdir.exists() {
                                             if let Err(e) = fs::remove_dir_all(&spleeter_output_subdir) {
-                                                eprintln!("⚠️ Impossible de supprimer le dossier de Spleeter {:?}: {}", spleeter_output_subdir, e);
+                                                warn!("⚠️ Impossible de supprimer le dossier de Spleeter {:?}: {}", spleeter_output_subdir, e);
                                             }
                                         }
                                     }
                                     Err(e) => {
-                                        eprintln!("❌ Erreur lors du renommage/déplacement du fichier instrumental: {}", e);
-                                        eprintln!("   L'instrumental brut de Spleeter se trouve peut-être ici : {:?}", spleeter_instrumental_path);
-                                        eprintln!("   Le fichier audio original a été conservé ici : {:?}", original_downloaded_full_path);
+                                        error!("❌ Erreur lors du renommage/déplacement du fichier instrumental: {}", e);
+                                        info!("   L'instrumental brut de Spleeter se trouve peut-être ici : {:?}", spleeter_instrumental_path);
+                                        info!("   Le fichier audio original a été conservé ici : {:?}", original_downloaded_full_path);
                                     }
                                 }
                             } else {
-                                eprintln!("❌ Fichier instrumental ('{}') non trouvé dans le dossier de sortie de Spleeter: {:?}", instrumental_spleeter_filename, spleeter_output_subdir);
-                                eprintln!("   Le fichier audio original a été conservé ici : {:?}", original_downloaded_full_path);
+                                error!("❌ Fichier instrumental ('{}') non trouvé dans le dossier de sortie de Spleeter: {:?}", instrumental_spleeter_filename, spleeter_output_subdir);
+                                info!("   Le fichier audio original a été conservé ici : {:?}", original_downloaded_full_path);
                             }
                         } else {
-                            eprintln!("❌ Spleeter a échoué avec le code de sortie : {:?}. Le fichier audio original a été conservé.", spleeter_status.code());
-                            eprintln!("   Chemin du fichier original : {:?}", original_downloaded_full_path);
+                            error!("❌ Spleeter a échoué avec le code de sortie : {:?}. Le fichier audio original a été conservé.", spleeter_status.code());
+                            info!("   Chemin du fichier original : {:?}", original_downloaded_full_path);
                         }
                     }
                     Err(e) => {
-                        eprintln!("❌ Erreur lors du lancement de Spleeter: {}. Le fichier audio original a été conservé.", e);
-                        eprintln!("   Chemin du fichier original : {:?}", original_downloaded_full_path);
+                        error!("❌ Erreur lors du lancement de Spleeter: {}. Le fichier audio original a été conservé.", e);
+                        info!("   Chemin du fichier original : {:?}", original_downloaded_full_path);
                     }
                 }
             }
             // If not extracting instrumental, the original audio is already there and its path printed.
         } else {
-            eprintln!("⚠️ Impossible de déterminer le nom du fichier audio téléchargé par yt-dlp.");
+            warn!("⚠️ Impossible de déterminer le nom du fichier audio téléchargé par yt-dlp.");
         }
     } else {
-        eprintln!("Erreur lors du téléchargement de l'audio par yt-dlp. Code: {:?}", status.code());
+        error!("Erreur lors du téléchargement de l'audio par yt-dlp. Code: {:?}", status.code());
         std::process::exit(1);
     }
 }

--- a/src/installers.rs
+++ b/src/installers.rs
@@ -1,18 +1,18 @@
-use std::path::Path;
 use std::process::Stdio;
 use std::process::{Command, exit};
 use std::env;
 use colored::*;
-use std::io::{self, Write};
 
 /// Vérifie si une commande système est disponible dans le PATH
 fn is_command_available(cmd: &str) -> bool {
     which::which(cmd).is_ok()
 }
 
+use log::{info, warn, error};
+
 /// Installe Homebrew (macOS) s'il est absent
 fn install_brew() -> bool {
-    println!("⚙️ Homebrew n'est pas installé. Installation en cours...");
+    info!("⚙️ Homebrew n'est pas installé. Installation en cours...");
 
     let cmd = r#"/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)""#;
 
@@ -25,19 +25,19 @@ fn install_brew() -> bool {
         .expect("Erreur lors de l'exécution du script d'installation de Homebrew.");
 
     if !status.success() {
-        eprintln!("{}", "❌ L'installation de Homebrew a échoué.".red());
-        eprintln!("Veuillez installer Homebrew manuellement et réessayer.");
+        error!("{}", "❌ L'installation de Homebrew a échoué.".red());
+        error!("Veuillez installer Homebrew manuellement et réessayer.");
         return false;
     }
 
-    println!("{}", "✅ Homebrew installé avec succès !".green());
-    println!("{}", "NOTE: Vous pourriez avoir besoin de redémarrer votre terminal ou de sourcer votre fichier de profil (ex: ~/.zshrc, ~/.bash_profile) pour que brew soit pleinement utilisable.".yellow());
+    info!("{}", "✅ Homebrew installé avec succès !".green());
+    info!("{}", "NOTE: Vous pourriez avoir besoin de redémarrer votre terminal ou de sourcer votre fichier de profil (ex: ~/.zshrc, ~/.bash_profile) pour que brew soit pleinement utilisable.".yellow());
     true
 }
 
 /// Installe Chocolatey (Windows) s'il est absent
 fn install_chocolatey() -> bool {
-    println!("⚙️ Chocolatey n'est pas installé. Installation en cours...");
+    info!("⚙️ Chocolatey n'est pas installé. Installation en cours...");
 
     let cmd = r#"Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))"#;
 
@@ -49,13 +49,13 @@ fn install_chocolatey() -> bool {
         .expect("Erreur lors de l'exécution du script d'installation de Chocolatey.");
 
     if !status.success() {
-        eprintln!("{}", "❌ L'installation de Chocolatey a échoué.".red());
-        eprintln!("Veuillez installer Chocolatey manuellement et réessayer.");
+        error!("{}", "❌ L'installation de Chocolatey a échoué.".red());
+        error!("Veuillez installer Chocolatey manuellement et réessayer.");
         return false;
     }
 
-    println!("{}", "✅ Chocolatey installé avec succès !".green());
-    println!("{}", "NOTE: Vous pourriez avoir besoin de redémarrer votre terminal pour que choco soit pleinement utilisable.".yellow());
+    info!("{}", "✅ Chocolatey installé avec succès !".green());
+    info!("{}", "NOTE: Vous pourriez avoir besoin de redémarrer votre terminal pour que choco soit pleinement utilisable.".yellow());
     true
 }
 
@@ -66,12 +66,12 @@ fn install_apt(package: &str) -> bool {
     } else if is_command_available("sudo") {
         ("sudo", vec!["apt"])
     } else {
-        eprintln!("{}", "❌ La commande 'sudo' est nécessaire pour 'apt' mais n'est pas trouvée et l'utilisateur n'est pas root.".red());
-        eprintln!("Veuillez installer le paquet '{}' manuellement ou exécuter en tant que root.", package);
+        error!("{}", "❌ La commande 'sudo' est nécessaire pour 'apt' mais n'est pas trouvée et l'utilisateur n'est pas root.".red());
+        error!("Veuillez installer le paquet '{}' manuellement ou exécuter en tant que root.", package);
         return false;
     };
 
-    println!("⚙️ Mise à jour des dépôts apt (peut nécessiter un mot de passe)...");
+    info!("⚙️ Mise à jour des dépôts apt (peut nécessiter un mot de passe)...");
     let mut update_args = base_args.clone();
     update_args.extend_from_slice(&["update", "-y"]);
 
@@ -81,10 +81,10 @@ fn install_apt(package: &str) -> bool {
         .expect("Erreur lors de la mise à jour des dépôts apt.");
 
     if !update_status.success() {
-        eprintln!("{}", "⚠️ Échec de la mise à jour des dépôts apt (apt update). Tentative d'installation quand même...".yellow());
+        warn!("{}", "⚠️ Échec de la mise à jour des dépôts apt (apt update). Tentative d'installation quand même...".yellow());
     }
 
-    println!("⚙️ Tentative d'installation de '{}' avec apt (peut nécessiter un mot de passe)...", package);
+    info!("⚙️ Tentative d'installation de '{}' avec apt (peut nécessiter un mot de passe)...", package);
     let mut install_args = base_args;
     install_args.extend_from_slice(&["install", "-y", package]);
 
@@ -94,10 +94,10 @@ fn install_apt(package: &str) -> bool {
         .expect(&format!("Erreur lors de l'installation de {} avec apt.", package));
 
     if !status.success() {
-        eprintln!("❌ L'installation de {} avec apt a échoué.", package.red());
+        error!("❌ L'installation de {} avec apt a échoué.", package.red());
         return false;
     }
-    println!("✅ {} installé avec succès via apt!", package.green());
+    info!("✅ {} installé avec succès via apt!", package.green());
     true
 }
 
@@ -108,7 +108,7 @@ fn install_brew_package(package: &str) -> bool {
             return false;
         }
     }
-    println!("⚙️ Tentative d'installation de '{}' avec brew...", package);
+    info!("⚙️ Tentative d'installation de '{}' avec brew...", package);
     let status = Command::new("brew")
         .args(&["install", package])
         .stdout(Stdio::inherit())
@@ -116,10 +116,10 @@ fn install_brew_package(package: &str) -> bool {
         .status()
         .expect(&format!("Erreur lors de l'exécution de brew install {}.", package));
     if !status.success() {
-        eprintln!("❌ L'installation de {} avec brew a échoué.", package.red());
+        error!("❌ L'installation de {} avec brew a échoué.", package.red());
         return false;
     }
-    println!("✅ {} installé avec succès via brew!", package.green());
+    info!("✅ {} installé avec succès via brew!", package.green());
     true
 }
 
@@ -130,7 +130,7 @@ fn install_choco_package(package: &str) -> bool {
             return false;
         }
     }
-    println!("⚙️ Tentative d'installation de '{}' avec choco...", package);
+    info!("⚙️ Tentative d'installation de '{}' avec choco...", package);
     let status = Command::new("choco")
         .args(&["install", package, "-y"])
         .stdout(Stdio::inherit())
@@ -138,17 +138,17 @@ fn install_choco_package(package: &str) -> bool {
         .status()
         .expect(&format!("Erreur lors de l'exécution de choco install {}.", package));
     if !status.success() {
-        eprintln!("❌ L'installation de {} avec choco a échoué.", package.red());
+        error!("❌ L'installation de {} avec choco a échoué.", package.red());
         return false;
     }
-    println!("✅ {} installé avec succès via choco!", package.green());
+    info!("✅ {} installé avec succès via choco!", package.green());
     true
 }
 
 /// Tentative d'installation via scoop (Windows)
 fn install_scoop_package(package: &str) -> bool {
     if !is_command_available("scoop") {
-        println!("⚙️ Scoop n'est pas installé. Tentative d'installation...");
+        info!("⚙️ Scoop n'est pas installé. Tentative d'installation...");
         let cmd = "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser; irm get.scoop.sh | iex";
         let status = Command::new("powershell")
             .args(&["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", cmd])
@@ -158,13 +158,13 @@ fn install_scoop_package(package: &str) -> bool {
             .expect("Erreur lors de l'installation de Scoop.");
 
         if !status.success() {
-            eprintln!("{}", "❌ L'installation de Scoop a échoué.".red());
+            error!("{}", "❌ L'installation de Scoop a échoué.".red());
             return false;
         }
-        println!("{}", "✅ Scoop installé avec succès!".green());
-        println!("{}", "NOTE: Vous pourriez avoir besoin de redémarrer votre terminal pour que scoop soit pleinement utilisable.".yellow());
+        info!("{}", "✅ Scoop installé avec succès!".green());
+        info!("{}", "NOTE: Vous pourriez avoir besoin de redémarrer votre terminal pour que scoop soit pleinement utilisable.".yellow());
     }
-    println!("⚙️ Tentative d'installation de '{}' avec scoop...", package);
+    info!("⚙️ Tentative d'installation de '{}' avec scoop...", package);
     let status = Command::new("scoop")
         .args(&["install", package])
         .stdout(Stdio::inherit())
@@ -172,32 +172,32 @@ fn install_scoop_package(package: &str) -> bool {
         .status()
         .expect(&format!("Erreur lors de l'installation de {} avec scoop.", package));
     if !status.success() {
-        eprintln!("❌ L'installation de {} avec scoop a échoué.", package.red());
+        error!("❌ L'installation de {} avec scoop a échoué.", package.red());
         return false;
     }
-    println!("✅ {} installé avec succès via scoop!", package.green());
+    info!("✅ {} installé avec succès via scoop!", package.green());
     true
 }
 
 /// Installe ffmpeg de manière multiplateforme
 pub fn install_ffmpeg() {
-    println!("⚙️ Installation de ffmpeg...");
+    info!("⚙️ Installation de ffmpeg...");
     let os = env::consts::OS;
     let success = match os {
         "linux" => install_apt("ffmpeg"),
         "macos" => install_brew_package("ffmpeg"),
         "windows" => install_choco_package("ffmpeg") || install_scoop_package("ffmpeg"),
         _ => {
-            eprintln!("❌ Système d'exploitation '{}' non supporté pour l'installation automatique de ffmpeg.", os.red());
+            error!("❌ Système d'exploitation '{}' non supporté pour l'installation automatique de ffmpeg.", os.red());
             false
         }
     };
 
     if !success {
-        eprintln!("{}", "❌ L'installation de ffmpeg a échoué. Veuillez l'installer manuellement.".red());
+        error!("{}", "❌ L'installation de ffmpeg a échoué. Veuillez l'installer manuellement.".red());
         exit(1);
     }
-    println!("{}", "✅ ffmpeg est maintenant prêt.".green());
+    info!("{}", "✅ ffmpeg est maintenant prêt.".green());
 }
 
 /// Helper function for installing yt-dlp on Linux
@@ -207,14 +207,14 @@ fn install_yt_dlp_linux_internal() -> bool {
     } else if is_command_available("sudo") {
         ("sudo ", false)
     } else {
-        eprintln!("{}", "❌ 'sudo' est requis pour installer yt-dlp globalement mais n'est pas trouvé.".red());
+        error!("{}", "❌ 'sudo' est requis pour installer yt-dlp globalement mais n'est pas trouvé.".red());
         return false;
     };
 
     let install_dir = "/usr/local/bin";
     let yt_dlp_path = format!("{}/yt-dlp", install_dir);
 
-    println!("Téléchargement de yt-dlp vers {}...", yt_dlp_path);
+    info!("Téléchargement de yt-dlp vers {}...", yt_dlp_path);
     let cmd_dl = format!(
         "{}curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o {}",
         sudo_prefix, yt_dlp_path
@@ -222,334 +222,62 @@ fn install_yt_dlp_linux_internal() -> bool {
     let status_dl = Command::new("sh").arg("-c").arg(&cmd_dl).status();
 
     if !status_dl.map_or(false, |s| s.success()) {
-        eprintln!("{}", "❌ Échec du téléchargement de yt-dlp.".red());
+        error!("{}", "❌ Échec du téléchargement de yt-dlp.".red());
         return false;
     }
 
-    println!("Configuration des permissions pour {}...", yt_dlp_path);
+    info!("Configuration des permissions pour {}...", yt_dlp_path);
     let cmd_chmod = format!("{}chmod a+rx {}", sudo_prefix, yt_dlp_path);
     let status_chmod = Command::new("sh").arg("-c").arg(&cmd_chmod).status();
 
     if !status_chmod.map_or(false, |s| s.success()) {
-        eprintln!("{}", "❌ Échec de la configuration des permissions pour yt-dlp.".red());
+        error!("{}", "❌ Échec de la configuration des permissions pour yt-dlp.".red());
         if sudo_prefix == "sudo " { // Attempt to clean up only if sudo was used for download
             let _ = Command::new("sh").arg("-c").arg(format!("{}rm -f {}", sudo_prefix, yt_dlp_path)).status();
         }
         return false;
     }
-    println!("{}", "✅ yt-dlp installé avec succès via curl!".green());
+    info!("{}", "✅ yt-dlp installé avec succès via curl!".green());
     true
 }
 
 
 /// Installe yt-dlp de manière multiplateforme
 pub fn install_yt_dlp() {
-    println!("⚙️ Installation de yt-dlp...");
+    info!("⚙️ Installation de yt-dlp...");
     let os = env::consts::OS;
     let success = match os {
         "linux" => install_yt_dlp_linux_internal(),
         "macos" => install_brew_package("yt-dlp"),
         "windows" => install_choco_package("yt-dlp") || install_scoop_package("yt-dlp"),
         _ => {
-            eprintln!("❌ Système d'exploitation '{}' non supporté pour l'installation automatique de yt-dlp.", os.red());
+            error!("❌ Système d'exploitation '{}' non supporté pour l'installation automatique de yt-dlp.", os.red());
             false
         }
     };
 
     if !success {
-        eprintln!("{}", "❌ L'installation de yt-dlp a échoué. Veuillez l'installer manuellement.".red());
+        error!("{}", "❌ L'installation de yt-dlp a échoué. Veuillez l'installer manuellement.".red());
         exit(1);
     }
-    println!("{}", "✅ yt-dlp est maintenant prêt.".green());
+    info!("{}", "✅ yt-dlp est maintenant prêt.".green());
 }
 
-/// Tente d'installer Spleeter et ses dépendances Python.
-fn do_install_spleeter_os_specific() -> bool {
-    let os = env::consts::OS;
-    let mut pip_ready = false;
-
-    // Déterminer l'interpréteur Python à utiliser
-    let mut initial_python_cmd_str = "python".to_string();
-    if os == "macos" {
-        let homebrew_python3_path = Path::new("/usr/local/bin/python3");
-        if homebrew_python3_path.exists() && is_command_available(homebrew_python3_path.to_str().unwrap_or_default()) {
-            initial_python_cmd_str = homebrew_python3_path.to_str().unwrap().to_string();
-        } else if is_command_available("python3") {
-            initial_python_cmd_str = "python3".to_string();
-        } else if is_command_available("python") {
-            // Reste "python"
-        } else {
-            eprintln!("{}", "❌ Aucun interpréteur Python (python3 ou python) n'a été trouvé.".red());
-            return false;
-        }
-    } else { // Pour Linux, Windows, etc.
-        if is_command_available("python3") {
-            initial_python_cmd_str = "python3".to_string();
-        } else if is_command_available("python") {
-            // Reste "python"
-        } else {
-            eprintln!("{}", "❌ Aucun interpréteur Python (python3 ou python) n'a été trouvé.".red());
-            return false;
-        }
-    }
-    let python_cmd_for_check = &initial_python_cmd_str;
-
-    // Vérifier si pip est fonctionnel avec l'interpréteur choisi
-    if Command::new(python_cmd_for_check).args(&["-m", "pip", "--version"]).status().map_or(false, |s| s.success()) {
-        pip_ready = true;
-    } else {
-        println!("🐍 Pip (gestionnaire de paquets Python) n'est pas trouvé ou n'est pas fonctionnel avec '{}'.", python_cmd_for_check);
-        match os {
-            "linux" => {
-                println!("Tentative d'installation de python3-pip via apt...");
-                if install_apt("python3-pip") { // install_apt devrait utiliser python3
-                    pip_ready = Command::new("python3").args(&["-m", "pip", "--version"]).status().map_or(false, |s| s.success());
-                    if pip_ready { initial_python_cmd_str = "python3".to_string(); }
-                }
-            }
-            "macos" => {
-                println!("Tentative d'installation de python via Homebrew (qui inclut pip)...");
-                if install_brew_package("python") { // Ceci installe python3 et pip3
-                    let homebrew_python3_path_str = "/usr/local/bin/python3";
-                    if Path::new(homebrew_python3_path_str).exists() && is_command_available(homebrew_python3_path_str) {
-                        initial_python_cmd_str = homebrew_python3_path_str.to_string();
-                        pip_ready = Command::new(homebrew_python3_path_str).args(&["-m", "pip", "--version"]).status().map_or(false, |s| s.success());
-                    } else if is_command_available("python3") { // Fallback
-                        initial_python_cmd_str = "python3".to_string();
-                        pip_ready = Command::new("python3").args(&["-m", "pip", "--version"]).status().map_or(false, |s| s.success());
-                    }
-                }
-            }
-            "windows" => {
-                println!("Tentative d'installation de python via Chocolatey (qui inclut pip)...");
-                if install_choco_package("python") {
-                    pip_ready = Command::new("python").args(&["-m", "pip", "--version"]).status().map_or(false, |s| s.success());
-                    if pip_ready { initial_python_cmd_str = "python".to_string(); }
-                }
-            }
-            _ => {
-                eprintln!("{}", "❌ Système d'exploitation non supporté pour l'installation automatique de Python/pip.".red());
-            }
-        }
-    }
-
-    if !pip_ready {
-        eprintln!("{}", "❌ Pip n'a pas pu être installé ou rendu fonctionnel. Spleeter ne peut pas être installé automatiquement.".red());
-        return false;
-    }
-
-    let final_python_cmd = &initial_python_cmd_str;
-
-    // --- Tentative de mise à jour de pip ---
-    println!("🐍 Pip est disponible avec '{}'. Tentative de mise à jour de pip...", final_python_cmd);
-    let mut pip_upgrade_args = vec!["-m", "pip", "install"];
-    if os == "macos" {
-        pip_upgrade_args.push("--break-system-packages");
-        pip_upgrade_args.push("--user");
-    }
-    pip_upgrade_args.push("--upgrade");
-    pip_upgrade_args.push("pip");
-
-    let pip_upgrade_output = Command::new(final_python_cmd)
-        .args(&pip_upgrade_args)
-        .output()
-        .expect("Erreur lors de l'exécution de la mise à jour de pip.");
-
-    if !pip_upgrade_output.status.success() {
-        println!("{}", "⚠️  La mise à jour de pip a échoué ou n'était pas nécessaire. Continuation...".yellow());
-    } else {
-        println!("{}", "✅ Pip mis à jour avec succès.".green());
-    }
-
-    // --- Tentative d'installation de Spleeter ---
-    println!("⚙️  Installation de Spleeter via pip avec '{}' (cela peut prendre plusieurs minutes à cause de TensorFlow)...", final_python_cmd);
-    let mut spleeter_install_args = vec!["-m", "pip", "install"];
-    if os == "macos" {
-        spleeter_install_args.push("--break-system-packages");
-        spleeter_install_args.push("--user");
-    }
-    spleeter_install_args.push("spleeter");
-
-    let spleeter_install_output = Command::new(final_python_cmd)
-        .args(&spleeter_install_args)
-        .output()
-        .expect("Erreur lors de l'exécution de pip install spleeter.");
-
-    if !spleeter_install_output.status.success() {
-        eprintln!("{}", "❌ L'installation de Spleeter via pip a échoué.".red());
-
-        eprintln!("{}", "   Une erreur technique est survenue lors de la tentative d'installation de Spleeter avec pip.".yellow());
-        eprintln!("{}", "   Cela est souvent dû à des incompatibilités avec votre version actuelle de Python ou des problèmes avec les dépendances de Spleeter (comme numpy ou TensorFlow).".yellow());
-
-        let spleeter_stderr_str = String::from_utf8_lossy(&spleeter_install_output.stderr);
-
-        eprintln!("   Vérifiez votre connexion internet.");
-        eprintln!("   Causes possibles : Incompatibilité de version Python (Spleeter/TensorFlow avec Python >3.11), PEP 668 (environnement externe), conflits de dépendances, permissions.");
-
-        if os == "macos" && spleeter_stderr_str.contains("externally-managed-environment") {
-            eprintln!("   L'option '--break-system-packages --user' a été tentée pour macOS pour gérer l'erreur 'externally-managed-environment'.");
-        }
-
-        if spleeter_stderr_str.contains("NameError: name 'CCompiler' is not defined") || (spleeter_stderr_str.contains("metadata-generation-failed") && spleeter_stderr_str.contains("numpy")) {
-            eprintln!("   L'erreur semble liée à la compilation de 'numpy', une dépendance de Spleeter. Cela se produit fréquemment avec des versions de Python trop récentes (comme 3.12+).");
-        } else {
-            eprintln!("   Si l'erreur concerne la compilation d'un paquet comme 'numpy', cela est souvent dû à une version de Python trop récente (comme 3.12+).");
-        }
-        eprintln!("   Spleeter et ses dépendances (notamment TensorFlow) sont plus stables avec Python 3.7-3.11.");
-
-        eprintln!("   Vous pouvez essayer d'exécuter cette commande manuellement pour plus de détails (cela affichera la sortie technique complète) :");
-        let mut manual_cmd_display_parts = vec![final_python_cmd.to_string(), "-m".to_string(), "pip".to_string(), "install".to_string()];
-        if os == "macos" {
-            manual_cmd_display_parts.push("--break-system-packages".to_string());
-            manual_cmd_display_parts.push("--user".to_string());
-        }
-        manual_cmd_display_parts.push("spleeter".to_string());
-        eprintln!("   {}", manual_cmd_display_parts.join(" "));
-        return false;
-    }
-
-    println!("{}", "✅ Spleeter semble avoir été installé avec succès via pip.".green());
-    println!("{}", "NOTE: Si la commande 'spleeter' n'est pas immédiatement trouvée,".yellow());
-    println!("{}", "      assurez-vous que le répertoire des scripts Python est dans votre PATH.".yellow());
-    if os == "macos" {
-        println!("{}", "      Pour les installations '--user' sur macOS, cela peut être '~/Library/Python/X.Y/bin' (remplacez X.Y par votre version Python).".yellow());
-    } else {
-        println!("{}", "      (Ex: ~/.local/bin sur Linux, ou %APPDATA%\\Python\\PythonXX\\Scripts sur Windows)".yellow());
-    }
-    println!("{}", "      Vous pourriez avoir besoin de redémarrer votre terminal ou votre session.".yellow());
-    true
-}
-
-/// Demande à l'utilisateur s'il souhaite continuer sans Spleeter après un échec d'installation.
-fn demander_continuer_sans_spleeter() -> bool {
-    loop {
-        print!("{}", "\n🤔 L'installation automatique de Spleeter a échoué. ".yellow());
-        print!("{}", "L'extraction instrumentale ne sera pas disponible.".yellow());
-        print!("{}", "\nSouhaitez-vous continuer à utiliser l'application pour les téléchargements de vidéos et d'audios (sans cette fonctionnalité) ? (o/N) : ".bold());
-        io::stdout().flush().unwrap_or_else(|e| eprintln!("Erreur lors du flush stdout: {}", e));
-
-        let mut reponse = String::new();
-        if io::stdin().read_line(&mut reponse).is_err() {
-            println!("{}", "❌ Erreur de lecture de votre réponse. Veuillez réessayer.".red());
-            continue;
-        }
-        let reponse = reponse.trim().to_lowercase();
-
-        if reponse == "o" {
-            println!("{}", "✅ D'accord, continuation sans l'extraction instrumentale.".green());
-            return true;
-        } else if reponse == "n" || reponse.is_empty() { // Default to No
-            println!("{}", "\n👋 Merci d'avoir utilisé Panther Downloader. À bientôt !\n".blue().bold());
-            return false;
-        } else {
-            println!("{}", "❌ Réponse invalide. Veuillez entrer 'o' pour oui ou 'n' pour non.".red());
-        }
-    }
-}
-
-
-/// Installe Spleeter si nécessaire.
-pub fn install_spleeter() {
-    println!("⚙️  Vérification et installation de Spleeter...");
-    if !do_install_spleeter_os_specific() { // Si l'installation automatique échoue
-        eprintln!("{}", "❌ L'installation automatique de Spleeter a échoué.".red());
-        eprintln!("{}", "----------------------------------------------------------------------".yellow());
-        eprintln!("{}", "IMPORTANT: Problème de compatibilité Python détecté pour Spleeter.".bold().red());
-        eprintln!("{}", "----------------------------------------------------------------------".yellow());
-        eprintln!("Spleeter et ses dépendances (comme TensorFlow et une ancienne version de numpy)");
-        eprintln!("sont souvent {} avec les versions très récentes de Python (ex: Python 3.12+).", "incompatibles".bold().red());
-        eprintln!("Votre version actuelle de Python semble causer des échecs lors de la compilation de ces dépendances.");
-
-        let os_type = env::consts::OS;
-        if os_type == "macos" {
-            eprintln!("\nPour résoudre cela sur votre Mac, la {} est d'utiliser un environnement Python dédié avec une version compatible (Python 3.9, 3.10, ou 3.11 sont recommandés).", "SOLUTION LA PLUS FIABLE".bold().green());
-            eprintln!("\n{} ÉTAPES DÉTAILLÉES POUR MAC (RECOMMANDÉ) :", "👉".green());
-            eprintln!("   -------------------------------------------------------------------");
-            eprintln!("   {} Objectif : Créer un environnement Python isolé avec Python 3.9 (par exemple) pour Spleeter.", "🎯".cyan());
-            eprintln!("   -------------------------------------------------------------------");
-            eprintln!("\n   1. {}Ouvrez une nouvelle fenêtre de Terminal{}.", "`".bold(), "`".bold());
-            eprintln!("\n   2. {}Installez une version compatible de Python via Homebrew (si pas déjà fait) :{}", "🐍".yellow(), "(Exemple avec Python 3.9)".italic());
-            eprintln!("      {} brew install python@3.9", "$".dimmed());
-            eprintln!("      {} (Cela rendra `python3.9` disponible)", "ℹ️".dimmed());
-            eprintln!("\n   3. {}Créez un environnement virtuel pour Spleeter avec cette version de Python :", "🛠️".yellow());
-            eprintln!("      {} python3.9 -m venv ~/spleeter_env", "$".dimmed());
-            eprintln!("      {} (Ceci crée un dossier `spleeter_env` dans votre répertoire personnel)", "ℹ️".dimmed());
-            eprintln!("\n   4. {}Activez cet environnement virtuel :", "💡".yellow());
-            eprintln!("      {} source ~/spleeter_env/bin/activate", "$".dimmed());
-            eprintln!("      {} (Votre invite de commande devrait maintenant commencer par `(spleeter_env)`)", "ℹ️".dimmed());
-            eprintln!("\n   5. {}Installez Spleeter DANS cet environnement activé :", "📦".yellow());
-            eprintln!("      {} pip install spleeter", "$".dimmed());
-            eprintln!("      {} (Cette installation a de fortes chances de réussir ici)", "ℹ️".dimmed());
-            eprintln!("\n   6. {}Utilisation future de Spleeter :", "🚀".yellow());
-            eprintln!("      {} Chaque fois que vous voudrez utiliser Spleeter (y compris avec cet outil),", "ℹ️".dimmed());
-            eprintln!("      {} vous devrez d'abord activer l'environnement : `source ~/spleeter_env/bin/activate`", "ℹ️".dimmed());
-            eprintln!("      {} Une fois Spleeter installé dans cet environnement, cet outil devrait pouvoir le trouver si l'environnement est actif.", "ℹ️".dimmed());
-            eprintln!("\n   7. {}Pour quitter l'environnement virtuel (quand vous avez fini) :", "🚪".yellow());
-            eprintln!("      {} deactivate", "$".dimmed());
-            eprintln!("\n{} AUTRE OPTION (moins recommandée, peut toujours échouer avec Python 3.12+) :", "⚠️".yellow());
-            eprintln!("   Si vous souhaitez toujours essayer avec votre Python global (actuellement {}) et que l'erreur PEP 668 était le problème principal :", env::var("PYTHON_VERSION").unwrap_or_else(|_| "inconnue".to_string()).italic());
-            eprintln!("     {} pip install --user spleeter", "$".dimmed());
-            eprintln!("     (Cela nécessite que {} soit dans votre PATH)", "~/Library/Python/X.Y/bin".italic());
-        } else {
-            // Instructions génériques pour les autres OS
-            eprintln!("\nIl est fortement recommandé d'utiliser un {} avec une version de Python compatible (Python 3.7-3.11).", "environnement virtuel Python".bold());
-            eprintln!("Veuillez consulter la documentation de Python pour créer un environnement virtuel sur votre système.");
-            eprintln!("Une fois l'environnement activé, exécutez : {} pip install spleeter", "$".dimmed());
-        }
-
-        eprintln!("\nConsultez la documentation officielle de Spleeter et TensorFlow pour les compatibilités de version.");
-
-        // Demander à l'utilisateur s'il veut continuer sans Spleeter
-        if !demander_continuer_sans_spleeter() {
-            exit(1); // Quitter si l'utilisateur ne veut pas continuer
-        }
-        // Si l'utilisateur veut continuer, la fonction se termine ici.
-        // Spleeter n'est pas installé, mais l'application ne quitte pas.
-    }
-}
+// This file no longer contains Spleeter installation logic.
 
 /// Vérifie et installe tous les outils nécessaires
 pub fn ensure_dependencies() {
-    println!("{}", "🔍 Vérification des dépendances...".bold());
-    let mut all_core_deps_ready = true;
+    info!("{}", "🔍 Vérification des dépendances...".bold());
 
     if !is_command_available("ffmpeg") {
-        install_ffmpeg(); // Cette fonction appelle exit(1) en cas d'échec
-        if !is_command_available("ffmpeg") { // Ne devrait pas être atteint si install_ffmpeg quitte
-            all_core_deps_ready = false;
-        }
+        install_ffmpeg(); // This function calls exit(1) on failure
     } else {
-        println!("{}", "✅ ffmpeg est déjà installé.".green());
+        info!("{}", "✅ ffmpeg est déjà installé.".green());
     }
 
     if !is_command_available("yt-dlp") {
-        install_yt_dlp(); // Cette fonction appelle exit(1) en cas d'échec
-        if !is_command_available("yt-dlp") { // Ne devrait pas être atteint
-            all_core_deps_ready = false;
-        }
+        install_yt_dlp(); // This function calls exit(1) on failure
     } else {
-        println!("{}", "✅ yt-dlp est déjà installé.".green());
-    }
-
-    let spleeter_initially_available = is_command_available("spleeter");
-    if !spleeter_initially_available {
-        install_spleeter(); // Gère maintenant la sortie si l'utilisateur ne veut pas continuer
-    } else {
-        println!("{}", "✅ Spleeter est déjà installé.".green());
-    }
-
-    // Message final
-    if all_core_deps_ready {
-        if is_command_available("spleeter") {
-            println!("{}", "🎉 Toutes les dépendances (y compris Spleeter) sont prêtes !".green().bold());
-        } else {
-            println!("{}", "✅ Les dépendances de base (ffmpeg, yt-dlp) sont prêtes.".green());
-            println!("{}", "⚠️ Spleeter n'a pas pu être installé ou n'est pas disponible. L'extraction instrumentale ne fonctionnera pas.".yellow());
-            println!("{}", "   L'application continuera pour les autres téléchargements.".yellow());
-        }
-    } else {
-        // Ce cas ne devrait pas être atteint si install_ffmpeg/yt-dlp quittent correctement en cas d'échec.
-        println!("{}", "❌ Certaines dépendances de base n'ont pas pu être installées. L'application ne peut pas continuer.".red());
-        exit(1);
+        info!("{}", "✅ yt-dlp est déjà installé.".green());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use crate::commands::check_command;
 use colored::*;
 use installers::ensure_dependencies;
 use std::io::{self, Write};
+use log::{info, warn, error};
 
 mod commands;
 mod downloader;
@@ -9,36 +10,49 @@ mod installers;
 mod progress;
 mod user_input;
 mod commands_test;
+#[cfg(test)]
+mod cookies_test;
+#[cfg(test)]
+mod config_test;
+mod cookies;
+mod config;
+mod settings;
 
 fn main() {
+    env_logger::init();
     // 🛠️ Vérification de la présence de yt-dlp et ffmpeg
     ensure_dependencies();
 
+    let spleeter_available = check_command("spleeter");
+    if !spleeter_available {
+        warn!("{}", "Spleeter not found. Instrumental extraction will be disabled.".yellow());
+    }
+
     // 💡 Vérification de la présence de "curl" (à adapter si besoin)
     if check_command("curl") {
-        println!("{}", "La commande 'curl' est disponible !".green());
+        info!("{}", "La commande 'curl' est disponible !".green());
     } else {
-        println!("{}", "La commande 'curl' n'est pas trouvée !".red());
+        warn!("{}", "La commande 'curl' n'est pas trouvée !".red());
         // std::process::exit(1); // Décommentez si curl est indispensable
     }
 
     loop {
-        afficher_interface();
+        afficher_interface(spleeter_available);
 
         print!("{}", "👉 Votre choix : ".bold());
         io::stdout().flush().unwrap_or_else(|e| {
-            eprintln!("Erreur lors du flush stdout: {}", e);
+            error!("Erreur lors du flush stdout: {}", e);
         });
 
         let mut choix = String::new();
         if io::stdin().read_line(&mut choix).is_err() {
-            println!("{}", "❌ Erreur de lecture de votre choix.".red());
+            error!("{}", "❌ Erreur de lecture de votre choix.".red());
             continue;
         }
         let choix = choix.trim();
 
         if choix.eq_ignore_ascii_case("q") {
-            println!(
+            info!(
                 "{}",
                 "\n👋 Merci d’avoir utilisé Panther Downloader. À bientôt !\n"
                     .blue()
@@ -53,31 +67,47 @@ fn main() {
                 let (format, keep_files) = user_input::choisir_format_et_options();
                 // Demander si l'utilisateur souhaite personnaliser le nom du fichier
                 let custom_filename = user_input::demander_nom_fichier_personnalise();
-                println!("{}", "\n📥 Téléchargement de la vidéo en cours...\n".cyan().bold());
+                info!("{}", "\n📥 Téléchargement de la vidéo en cours...\n".cyan().bold());
                 // Note: La fonction download_video n'est pas modifiée pour l'extraction instrumentale
                 downloader::download_video(&url, &format, keep_files, custom_filename);
             }
             "2" => {
                 let url = demander_url();
+                let (format, keep_files) = user_input::choisir_video_options_avances();
+                // Demander si l'utilisateur souhaite personnaliser le nom du fichier
+                let custom_filename = user_input::demander_nom_fichier_personnalise();
+                info!("{}", "\n📥 Téléchargement de la vidéo en cours...\n".cyan().bold());
+                // Note: La fonction download_video n'est pas modifiée pour l'extraction instrumentale
+                downloader::download_video(&url, &format, keep_files, custom_filename);
+            }
+            "3" => {
+                let url = demander_url();
                 let audio_format = user_input::choisir_audio_format();
                 // On demande ici si l'utilisateur veut l'instrumental
-                let _extract_instrumental = user_input::demander_extraction_instrumental();
+                let _extract_instrumental = user_input::demander_extraction_instrumental(spleeter_available);
                 // Demander si l'utilisateur souhaite personnaliser le nom du fichier
                 let custom_filename = user_input::demander_nom_fichier_personnalise();
 
-                println!("{}", "\n📥 Téléchargement de l'audio en cours...\n".cyan().bold());
+                info!("{}", "\n📥 Téléchargement de l'audio en cours...\n".cyan().bold());
                 // Assurez-vous que votre fonction download_audio accepte ce nouveau paramètre
                 downloader::download_audio(&url, &audio_format, _extract_instrumental, custom_filename);
             }
+            "4" => {
+                let url = demander_url();
+                cookies::extract_cookies_and_download(&url);
+            }
+            "5" => {
+                settings::show_settings_menu();
+            }
             _ => {
-                println!("{}", "❌ Choix invalide. Veuillez entrer 1, 2 ou q.".red());
+                warn!("{}", "❌ Choix invalide. Veuillez entrer 1, 2, 3, 4, 5 ou q.".red());
                 continue;
             }
         }
 
         // Utilise la fonction centralisée pour demander si on continue
         if !user_input::demander_si_continuer() {
-            println!(
+            info!(
                 "{}",
                 "\n👋 Merci d’avoir utilisé Panther Downloader. À bientôt !\n"
                     .blue()
@@ -88,32 +118,39 @@ fn main() {
     }
 }
 
-fn afficher_interface() {
+fn afficher_interface(spleeter_available: bool) {
     println!("\n╔══════════════════════════════════════════════════╗");
-    println!("║     🎶 Panther Downloader - Audio & Vidéo 🎶       ║"); 
+    println!("║     🎶 Panther Downloader - Audio & Vidéo 🎶       ║");
     println!("╚══════════════════════════════════════════════════╝\n");
-
-    println!("Choisissez une option :");
-    println!("   [1] 🎥 Télécharger une vidéo");
-    println!("   [2] 🎧 Télécharger de l'audio (avec option instrumental)");
-    println!("   [q] ❌ Quitter");
+    println!("{}", "--- Downloads ---".bold());
+    println!("   [1] 🎥 Download Video (Quick)");
+    println!("   [2] 🎬 Download Video (Advanced)");
+    if spleeter_available {
+        println!("   [3] 🎧 Download Audio (with instrumental extraction)");
+    } else {
+        println!("   [3] 🎧 Download Audio {}", "(instrumental extraction disabled)".dimmed());
+    }
+    println!("   [4] 🍪 Download with Cookies");
+    println!("{}", "--- Management ---".bold());
+    println!("   [5] ⚙️  Settings");
+    println!("   [q] ❌ Quit");
 }
 
 fn demander_url() -> String {
     loop {
         print!("{}", "🔗 Entrez l'URL (ex: YouTube, Soundcloud) :\n👉 ".bold());
         io::stdout().flush().unwrap_or_else(|e| {
-            eprintln!("Erreur lors du flush stdout: {}", e);
+            error!("Erreur lors du flush stdout: {}", e);
         });
 
         let mut url = String::new();
         if io::stdin().read_line(&mut url).is_err() {
-            println!("{}", "❌ Erreur de lecture de l'URL.".red());
+            error!("{}", "❌ Erreur de lecture de l'URL.".red());
             continue; // Redemande l'URL en cas d'erreur de lecture
         }
         let url = url.trim();
         if url.is_empty() {
-            println!("{}", " L'URL ne peut pas être vide. Veuillez réessayer.".yellow());
+            warn!("{}", " L'URL ne peut pas être vide. Veuillez réessayer.".yellow());
         } else {
             return url.to_string();
         }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,206 @@
+use crate::config::{self, Config};
+use colored::*;
+use dialoguer::{Confirm, Input, Select, theme::ColorfulTheme};
+use log::{info, warn, error};
+
+pub fn show_settings_menu() {
+    loop {
+        let mut config = config::load_config();
+        let menu_items = [
+            "View Current Settings",
+            "Set default video format",
+            "Set download directory",
+            "Toggle keep temporary files",
+            "Manage audio formats",
+            "Back to main menu",
+        ];
+
+        let selection = Select::with_theme(&ColorfulTheme::default())
+            .with_prompt("Settings Menu")
+            .items(&menu_items)
+            .default(0)
+            .interact_opt()
+            .unwrap_or(None);
+
+        match selection {
+            Some(0) => view_current_settings(&config),
+            Some(1) => set_default_video_format(&mut config),
+            Some(2) => set_download_directory(&mut config),
+            Some(3) => toggle_keep_temporary_files(&mut config),
+            Some(4) => show_audio_formats_menu(),
+            Some(5) => break,
+            None => break,
+            _ => (),
+        }
+    }
+}
+
+
+fn view_current_settings(config: &Config) {
+    info!("{}", "Current Settings:".bold().underline());
+    info!("- Default Video Format: {}", config.default_video_format.yellow());
+    info!("- Download Directory: {}", config.download_directory.yellow());
+    info!("- Keep Temporary Files: {}", if config.keep_temporary_files { "Yes".green() } else { "No".red() });
+    info!("- Default Audio Format: {}", config.default_audio_format.yellow());
+    info!("- Available Audio Formats: {}", config.audio_formats.join(", ").yellow());
+}
+
+fn set_default_video_format(config: &mut Config) {
+    let input: String = Input::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter the new default video format (e.g., mp4, webm)")
+        .default(config.default_video_format.clone())
+        .interact_text()
+        .unwrap_or_else(|_| "".to_string());
+
+    if !input.is_empty() {
+        config.default_video_format = input;
+        config::save_config(config);
+        info!("{} {}", "Default video format set to:".green(), config.default_video_format.yellow());
+    } else {
+        warn!("{}", "Invalid input.".red());
+    }
+}
+
+use std::path::Path;
+
+fn set_download_directory(config: &mut Config) {
+    let input: String = Input::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter the new download directory")
+        .default(config.download_directory.clone())
+        .validate_with(|input: &String| -> Result<(), &str> {
+            if Path::new(input).is_dir() {
+                Ok(())
+            } else {
+                Err("This is not a valid directory.")
+            }
+        })
+        .interact_text()
+        .unwrap_or_else(|_| "".to_string());
+
+    if !input.is_empty() {
+        config.download_directory = input;
+        config::save_config(config);
+        info!("{} {}", "Download directory set to:".green(), config.download_directory.yellow());
+    } else {
+        warn!("{}", "Invalid input.".red());
+    }
+}
+
+fn toggle_keep_temporary_files(config: &mut Config) {
+    let current_status = config.keep_temporary_files;
+    let confirmation = Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt(format!("Keep temporary files is currently {}. Do you want to toggle it?", if current_status { "ON".green() } else { "OFF".red() }))
+        .interact_opt()
+        .unwrap_or(None);
+
+    if let Some(true) = confirmation {
+        config.keep_temporary_files = !current_status;
+        config::save_config(config);
+        info!("{} {}", "Keep temporary files set to:".green(), if config.keep_temporary_files { "ON".green() } else { "OFF".red() });
+    } else {
+        warn!("{}", "No changes made.".yellow());
+    }
+}
+
+fn show_audio_formats_menu() {
+    loop {
+        let mut config = config::load_config();
+        let menu_items = [
+            "View default audio format",
+            "Set default audio format",
+            "Add an audio format",
+            "Remove an audio format",
+            "Back to settings menu",
+        ];
+
+        let selection = Select::with_theme(&ColorfulTheme::default())
+            .with_prompt("Audio Formats Menu")
+            .items(&menu_items)
+            .default(0)
+            .interact_opt()
+            .unwrap_or(None);
+
+        match selection {
+            Some(0) => info!("{} {}", "Current default audio format:".cyan(), config.default_audio_format.yellow()),
+            Some(1) => set_default_format(&mut config),
+            Some(2) => add_audio_format(&mut config),
+            Some(3) => remove_audio_format(&mut config),
+            Some(4) => break,
+            None => break,
+            _ => (),
+        }
+    }
+}
+
+fn set_default_format(config: &mut Config) {
+    let selection = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Select a new default audio format")
+        .items(&config.audio_formats)
+        .default(0)
+        .interact_opt()
+        .unwrap_or(None);
+
+    if let Some(index) = selection {
+        config.default_audio_format = config.audio_formats[index].clone();
+        config::save_config(config);
+        info!("{} {}", "Default audio format set to:".green(), config.default_audio_format.yellow());
+    } else {
+        warn!("{}", "No selection made.".yellow());
+    }
+}
+
+fn add_audio_format(config: &mut Config) {
+    let new_format: String = Input::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter the new audio format (e.g., opus)")
+        .interact_text()
+        .unwrap_or_else(|_| "".to_string());
+
+    if new_format.is_empty() {
+        warn!("{}", "Invalid format.".red());
+        return;
+    }
+
+    if config.audio_formats.contains(&new_format) {
+        warn!("{} {}", "Format already exists:".red(), new_format.yellow());
+        return;
+    }
+
+    config.audio_formats.push(new_format.clone());
+    config::save_config(config);
+    info!("{} {}", "Added new format:".green(), new_format.yellow());
+}
+
+fn remove_audio_format(config: &mut Config) {
+    if config.audio_formats.len() <= 1 {
+        error!("{}", "You cannot remove the last audio format.".red());
+        return;
+    }
+
+    let selection = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Select an audio format to remove")
+        .items(&config.audio_formats)
+        .default(0)
+        .interact_opt()
+        .unwrap_or(None);
+
+    if let Some(index) = selection {
+        let removed_format = config.audio_formats[index].clone();
+        let confirmation = Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt(format!("Are you sure you want to remove '{}'?", removed_format))
+            .interact_opt()
+            .unwrap_or(None);
+
+        if let Some(true) = confirmation {
+            config.audio_formats.remove(index);
+            if removed_format == config.default_audio_format {
+                config.default_audio_format = config.audio_formats[0].clone();
+            }
+            config::save_config(config);
+            info!("{} {}", "Removed format:".green(), removed_format.yellow());
+        } else {
+            warn!("{}", "Removal cancelled.".yellow());
+        }
+    } else {
+        warn!("{}", "No selection made.".yellow());
+    }
+}

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -1,19 +1,22 @@
+use crate::config;
+use dialoguer::{Confirm, Input, Select, theme::ColorfulTheme};
 use std::io;
+use log::{info, warn};
 
 /// Fonction pour demander à l'utilisateur s'il souhaite personnaliser le nom du fichier à télécharger.
 pub fn demander_nom_fichier_personnalise() -> Option<String> {
-    println!("Souhaitez-vous personnaliser le nom du fichier à télécharger ? (o/n) :");
     let mut reponse = String::new();
+    info!("Souhaitez-vous personnaliser le nom du fichier à télécharger ? (o/n) :");
     io::stdin().read_line(&mut reponse).expect("Erreur de lecture de la réponse de l'utilisateur");
 
     if reponse.trim().eq_ignore_ascii_case("o") {
-        println!("Entrez le nom du fichier souhaité (sans l'extension) :");
+        info!("Entrez le nom du fichier souhaité (sans l'extension) :");
         let mut nom_fichier = String::new();
         io::stdin().read_line(&mut nom_fichier).expect("Erreur de lecture du nom de fichier");
         let nom_fichier = nom_fichier.trim().to_string();
 
         if nom_fichier.is_empty() {
-            println!("Aucun nom personnalisé fourni, le nom par défaut sera utilisé.");
+            warn!("Aucun nom personnalisé fourni, le nom par défaut sera utilisé.");
             None
         } else {
             Some(nom_fichier)
@@ -25,40 +28,79 @@ pub fn demander_nom_fichier_personnalise() -> Option<String> {
 
 /// Fonction pour demander à l'utilisateur le format vidéo et s'il souhaite conserver les fichiers originaux après la fusion.
 pub fn choisir_format_et_options() -> (String, bool) {
-    println!("Entrez le format de sortie (ex. 'mp4', 'webm', laissez vide pour le format par défaut) :");
-    let mut format = String::new();
-    io::stdin().read_line(&mut format).expect("Erreur de lecture du format de sortie");
-    let format = format.trim().to_string();
+    let config = config::load_config();
+    let default_format = config.default_video_format;
+    let keep_files = config.keep_temporary_files;
 
-    println!("Voulez-vous conserver les fichiers originaux après la fusion ? (o/n) :");
-    let mut keep_files_input = String::new();
-    io::stdin().read_line(&mut keep_files_input).expect("Erreur de lecture du choix de l'utilisateur");
-    let keep_files = keep_files_input.trim().eq_ignore_ascii_case("o");
+    let format: String = Input::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter the output format (leave empty for default)")
+        .default(default_format)
+        .interact_text()
+        .unwrap_or_else(|_| "mp4".to_string());
+
+    let keep_files = Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt("Keep original files after merge?")
+        .default(keep_files)
+        .interact()
+        .unwrap_or(false);
+
+    (format, keep_files)
+}
+
+pub fn choisir_video_options_avances() -> (String, bool) {
+    let resolutions = &["best", "1080p", "720p", "480p"];
+    let selection = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Select video resolution")
+        .items(resolutions)
+        .default(0)
+        .interact()
+        .unwrap();
+
+    let format = resolutions[selection].to_string();
+
+    let keep_files = Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt("Keep original files after merge?")
+        .default(false)
+        .interact()
+        .unwrap_or(false);
 
     (format, keep_files)
 }
 
 /// Fonction pour demander à l'utilisateur le format audio.
 pub fn choisir_audio_format() -> String {
-    println!("Entrez le format de sortie audio (ex. 'mp3', 'aac', 'flac', 'wav') :");
-    let mut audio_format = String::new();
-    io::stdin().read_line(&mut audio_format).expect("Erreur de lecture du format audio");
-    audio_format.trim().to_string()
+    let config = config::load_config();
+    let formats = &config.audio_formats;
+    let default_format = &config.default_audio_format;
+
+    let default_index = formats.iter().position(|f| f == default_format).unwrap_or(0);
+
+    let selection = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Choisissez un format audio")
+        .items(formats)
+        .default(default_index)
+        .interact()
+        .unwrap();
+
+    formats[selection].clone()
 }
 
 /// Fonction pour demander à l'utilisateur s'il souhaite extraire uniquement la piste instrumentale.
 /// Nécessite que Spleeter soit installé et accessible.
-pub fn demander_extraction_instrumental() -> bool {
-    println!("Voulez-vous extraire uniquement la piste instrumentale (sans les paroles) ? (o/n)");
-    println!("Note : Ceci nécessite que Spleeter soit installé sur votre système.");
-    let mut reponse = String::new();
-    io::stdin().read_line(&mut reponse).expect("Erreur de lecture de la réponse de l'utilisateur");
-    reponse.trim().eq_ignore_ascii_case("o")
+pub fn demander_extraction_instrumental(spleeter_available: bool) -> bool {
+    if !spleeter_available {
+        return false;
+    }
+    Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt("Voulez-vous extraire uniquement la piste instrumentale (sans les paroles) ?")
+        .default(false)
+        .interact()
+        .unwrap_or(false)
 }
 
 /// Fonction pour demander à l'utilisateur s'il souhaite continuer ou quitter le programme.
 pub fn demander_si_continuer() -> bool {
-    println!("Souhaitez-vous continuer à télécharger d'autres fichiers ? (o/n) :");
+    info!("Souhaitez-vous continuer à télécharger d'autres fichiers ? (o/n) :");
     let mut reponse = String::new();
     io::stdin().read_line(&mut reponse).expect("Erreur de lecture de la réponse de l'utilisateur");
     reponse.trim().eq_ignore_ascii_case("o")


### PR DESCRIPTION
This commit fixes a critical bug where the application would freeze during interactive prompts from the `dialoguer` crate, particularly after the "Keep original files after merge?" step.

The issue was caused by a combination of incorrect import statements and using the `.interact_opt()` method, which is intended for optional input and was not being handled correctly, leading to a hang.

The following changes have been made to `src/user_input.rs`:
- All `dialoguer` imports have been consolidated and corrected at the top of the file.
- All calls to `.interact_opt()` have been replaced with the standard `.interact()` method, which is more appropriate for these mandatory prompts.
- Unused import warnings in `src/installers.rs` were also cleaned up as part of this fix.

This ensures that all interactive menus are now robust and no longer cause the application to freeze.